### PR TITLE
Be explicit of resource path existance.

### DIFF
--- a/FlappyBird/GameViewController.swift
+++ b/FlappyBird/GameViewController.swift
@@ -14,7 +14,7 @@ extension SKNode {
         
         let path = NSBundle.mainBundle().pathForResource(file, ofType: "sks")
         
-        let sceneData = NSData.dataWithContentsOfFile(path, options: .DataReadingMappedIfSafe, error: nil)
+        let sceneData = NSData.dataWithContentsOfFile(path!, options: .DataReadingMappedIfSafe, error: nil)
         let archiver = NSKeyedUnarchiver(forReadingWithData: sceneData)
         
         archiver.setClass(self.classForKeyedUnarchiver(), forClassName: "SKScene")


### PR DESCRIPTION
Hi

I found that FlappySwift couldn't build using Xcode6-beta6 / Mac OS X 10.9.4
Maybe some of the Foundation API's implicit/explicit state has changed.

Please check this PR.
Thank you.
