### PR TITLE
Minor maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ DerivedData
 #
 Pods/
 
+.DS_Store

--- a/FlappyBird.xcodeproj/project.pbxproj
+++ b/FlappyBird.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 				437451FB193D163700654986 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		437451FB193D163700654986 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Ignore `.DS_Store` files: they clog up git.
Force the use of spaces in the Xcode project, because some people prefer tabs that can make merging back stuff really difficult.