### PR TITLE
Fix compilation errors in Swift 1.2 (Xcode 6.3 beta).

### DIFF
--- a/FlappyBird/AppDelegate.swift
+++ b/FlappyBird/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: NSDictionary?) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/FlappyBird/GameScene.swift
+++ b/FlappyBird/GameScene.swift
@@ -203,7 +203,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate{
         moving.speed = 1
     }
     
-    override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
+    override func touchesBegan(touches: Set<NSObject>, withEvent event: UIEvent) {
         /* Called when a touch begins */
         if moving.speed > 0  {
             for touch: AnyObject in touches {

--- a/FlappyBird/GameViewController.swift
+++ b/FlappyBird/GameViewController.swift
@@ -12,13 +12,13 @@ import SpriteKit
 extension SKNode {
     class func unarchiveFromFile(file : NSString) -> SKNode? {
         
-        let path = NSBundle.mainBundle().pathForResource(file, ofType: "sks")
+        let path = NSBundle.mainBundle().pathForResource((file as String), ofType: "sks")
         
         let sceneData = NSData(contentsOfFile: path!, options: .DataReadingMappedIfSafe, error: nil)
         let archiver = NSKeyedUnarchiver(forReadingWithData: sceneData!)
         
         archiver.setClass(self.classForKeyedUnarchiver(), forClassName: "SKScene")
-        let scene = archiver.decodeObjectForKey(NSKeyedArchiveRootObjectKey) as GameScene
+        let scene = archiver.decodeObjectForKey(NSKeyedArchiveRootObjectKey) as! GameScene
         archiver.finishDecoding()
         return scene
     }
@@ -31,7 +31,7 @@ class GameViewController: UIViewController {
 
         if let scene = GameScene.unarchiveFromFile("GameScene") as? GameScene {
             // Configure the view.
-            let skView = self.view as SKView
+            let skView = self.view as! SKView
             skView.showsFPS = true
             skView.showsNodeCount = true
             


### PR DESCRIPTION
1. AppDelegate:
The type of the launchOptions parameter of the didFinishLaunchingWithOptions function was changed in Swift 1.2.
- "launchOptions: NSDictionary?"
- has become: "launchOptions: [NSObject: AnyObject]?"

2. GameScene:
Swift 1.2 has introduced a native Set type that bridges with NSSet.
- override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
- has become: override func touchesBegan(touches: Set<NSObject>, withEvent event: UIEvent) {

3. GameViewController:
Forced conversions in Swift 1.2 are represented with as!. This makes it clear that the conversion may fail if you attempt to downcast to a type that doesn’t represent the value’s type.
- let scene = archiver.decodeObjectForKey(NSKeyedArchiveRootObjectKey) as GameScene
- has become: let scene = archiver.decodeObjectForKey(NSKeyedArchiveRootObjectKey) as! GameScene
- let skView = self.view as SKView
- has become: let skView = self.view as! SKView

NSString objects need to be converted to a Swift String value by casting.
- let path = NSBundle.mainBundle().pathForResource(file, ofType: "sks")
- has become: let path = NSBundle.mainBundle().pathForResource((file as String), ofType: "sks")